### PR TITLE
Fix logout/login functionality with proper URLs

### DIFF
--- a/accounts/templates/accounts/base.html
+++ b/accounts/templates/accounts/base.html
@@ -68,14 +68,14 @@
             </div>
             {% if user.is_authenticated %}
             <div class="nav-item">
-                <a href="/admin/logout/">
+                <a href="{% url 'accounts:logout' %}">
                     <i class="fas fa-sign-out-alt"></i>
                     <span>Logout ({{ user.get_full_name|default:user.email }})</span>
                 </a>
             </div>
             {% else %}
             <div class="nav-item">
-                <a href="/admin/login/">
+                <a href="{% url 'accounts:login' %}">
                     <i class="fas fa-sign-in-alt"></i>
                     <span>Login</span>
                 </a>

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -46,4 +46,7 @@ urlpatterns = [
     # Key Personnel (Singleton)
     path("keypersonnel/", crud_views.keypersonnel_detail, name="keypersonnel_detail"),
     path("keypersonnel/edit/", crud_views.keypersonnel_edit, name="keypersonnel_edit"),
+    # Authentication
+    path("logout/", views.logout_view, name="logout"),
+    path("login/", views.custom_login_view, name="login"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,1 +1,26 @@
-from django.shortcuts import render
+from django.contrib import messages
+from django.contrib.auth import logout
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect, render
+
+
+@login_required
+def logout_view(request):
+    """Logout view that redirects to dashboard"""
+    logout(request)
+    messages.success(request, "You have been successfully logged out.")
+    return redirect("core:index")  # Redirect to home page
+
+
+def custom_login_view(request):
+    """Redirect to admin login but return to accounts dashboard"""
+    from django.contrib.admin.views.decorators import staff_member_required
+    from django.urls import reverse
+
+    # If user is already authenticated, redirect to dashboard
+    if request.user.is_authenticated:
+        return redirect("accounts:dashboard")
+
+    # Otherwise redirect to admin login with next parameter
+    admin_login_url = "/admin/login/?next=" + reverse("accounts:dashboard")
+    return redirect(admin_login_url)


### PR DESCRIPTION
- Added logout_view and custom_login_view to accounts/views.py
- Created proper URL patterns for /accounts/logout/ and /accounts/login/
- Updated base.html template to use Django URL names instead of hardcoded paths
- Logout now properly clears session and redirects to home page
- Login redirects through admin but returns to accounts dashboard
- Fixed dead link issue - logout now functional
- Applied isort and black formatting (1 file reformatted)